### PR TITLE
handle radio buttons with per-choice selectors unitedstates/contact-cong...

### DIFF
--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -194,7 +194,11 @@ class CongressMember < ActiveRecord::Base
         when "uncheck"
           session.find(a.selector).set(false)
         when "choose"
-          session.choose(f[a.value])
+          if a.selector.nil?
+            session.choose(f[a.value])
+          else
+            session.choose(a.selector)
+          end
         end
       end
 


### PR DESCRIPTION
...ress#497

Radio buttons seem ill-served with a single per-action selector. You really need to be able to pick out the specific button. For instance on [Sen. Gillibrand's contact form](http://www.gillibrand.senate.gov/contact) there are the following: 

```
<div>
    <input name="subject" type="radio" value="Afghanistan" id="subject_Afghanistan">
    <span>Afghanistan</span>
    <div class="clear"><!-- --></div>
</div>
<div>
    <input name="subject" type="radio" value="Agriculture" id="subject_Agriculture">
    <span>Agriculture</span>
    <div class="clear"><!-- --></div>
</div>
```

I checked in a [yaml format](https://github.com/unitedstates/contact-congress/blob/master/members/G000555.yaml#L180-L186) I think will work with this change:

```
- choose:
        - name: subject
          value: $TOPIC
          required: true
          options:
            - Afghanistan : subject_Afghanistan
            - Agriculture : subject_Agriculture
```

For completeness' sake here's the link to the [form test page](http://efforg.github.io/congress-forms-test/?bioguide_id=G000555).
