### PR TITLE
Specify gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,40 +12,40 @@ ruby "2.1.0"
 # gem 'oj'
 
 # Project requirements
-gem 'rake'
+gem 'rake', '10.1.0'
 
 # Component requirements
-gem 'slim'
+gem 'slim', '2.0.2'
 
 # Test requirements
 group :test do
-  gem 'rspec'
-  gem 'rack-test', :require => 'rack/test'
-  gem 'factory_girl'
-  gem 'typhoeus'
+  gem 'rspec', '2.14.1'
+  gem 'rack-test', '0.6.2', :require => 'rack/test'
+  gem 'factory_girl', '4.3.0'
+  gem 'typhoeus', '0.6.7'
 end
 
 group :local do
-  gem 'watir-webdriver'
-  gem 'headless'
+  gem 'watir-webdriver', '0.6.4'
+  gem 'headless', '1.0.1'
 end
 
 # Padrino Stable Gem
 gem 'padrino', '0.11.4'
 
-gem 'database_cleaner'
-gem 'redcarpet'
-gem 'rack-parser', :require => 'rack/parser'
-gem 'activerecord', :require => "active_record"
-gem 'mysql2'
-gem 'pg'
-gem 'enumerize'
-gem 'mini_magick'
-gem 'delayed_job_active_record'
-gem 'capybara'
-gem 'poltergeist'
-gem 'git'
-gem 'thin'
+gem 'database_cleaner', '1.2.0'
+gem 'redcarpet', '3.0.0'
+gem 'rack-parser', '0.4.0', :require => 'rack/parser'
+gem 'activerecord', '3.2.15', :require => "active_record"
+gem 'mysql2', '0.3.14'
+gem 'pg', '0.17.1'
+gem 'enumerize', '0.7.0'
+gem 'mini_magick', '3.7.0'
+gem 'delayed_job_active_record', '4.0.0'
+gem 'capybara', '2.2.1'
+gem 'poltergeist', '1.5.0'
+gem 'git', '1.2.6'
+gem 'thin', '1.6.1'
 
 # Or Padrino Edge
 # gem 'padrino', :github => 'padrino/padrino-framework'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     activesupport (3.2.15)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
-    arel (3.0.2)
+    arel (3.0.3)
     builder (3.0.4)
     capybara (2.2.1)
       mime-types (>= 1.16)
@@ -20,20 +20,20 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    childprocess (0.4.0)
+    childprocess (0.5.2)
       ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
     daemons (1.1.9)
     database_cleaner (1.2.0)
-    delayed_job (4.0.0)
-      activesupport (>= 3.0, < 4.1)
+    delayed_job (4.0.1)
+      activesupport (>= 3.0, < 4.2)
     delayed_job_active_record (4.0.0)
       activerecord (>= 3.0, < 4.1)
       delayed_job (>= 3.0, < 4.1)
     diff-lcs (1.2.5)
     enumerize (0.7.0)
       activesupport (>= 3.2)
-    ethon (0.6.2)
+    ethon (0.6.3)
       ffi (>= 1.3.0)
       mime-types (~> 1.18)
     eventmachine (1.0.3)
@@ -42,18 +42,18 @@ GEM
     ffi (1.9.3)
     git (1.2.6)
     headless (1.0.1)
-    http_router (0.11.0)
+    http_router (0.11.1)
       rack (>= 1.0.0)
       url_mount (~> 0.2.1)
-    i18n (0.6.5)
+    i18n (0.6.9)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mime-types (1.25)
+    mime-types (1.25.1)
     mini_magick (3.7.0)
       subexec (~> 0.2.1)
-    mini_portile (0.5.2)
-    multi_json (1.8.2)
+    mini_portile (0.5.3)
+    multi_json (1.9.2)
     mysql2 (0.3.14)
     nokogiri (1.6.1)
       mini_portile (~> 0.5.0)
@@ -92,11 +92,11 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
-    polyglot (0.3.3)
+    polyglot (0.3.4)
     rack (1.5.2)
     rack-parser (0.4.0)
       rack
-    rack-protection (1.5.1)
+    rack-protection (1.5.3)
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -106,17 +106,17 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.7)
-    rspec-expectations (2.14.4)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.4)
-    rubyzip (1.1.0)
-    selenium-webdriver (2.39.0)
-      childprocess (>= 0.2.5)
+    rspec-mocks (2.14.6)
+    rubyzip (1.1.3)
+    selenium-webdriver (2.41.0)
+      childprocess (>= 0.5.0)
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0.4)
-    sinatra (1.4.4)
+    sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
@@ -136,7 +136,7 @@ GEM
       polyglot (>= 0.3.1)
     typhoeus (0.6.7)
       ethon (~> 0.6.2)
-    tzinfo (0.3.38)
+    tzinfo (0.3.39)
     url_mount (0.2.1)
       rack
     watir-webdriver (0.6.4)
@@ -150,25 +150,25 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord
-  capybara
-  database_cleaner
-  delayed_job_active_record
-  enumerize
-  factory_girl
-  git
-  headless
-  mini_magick
-  mysql2
+  activerecord (= 3.2.15)
+  capybara (= 2.2.1)
+  database_cleaner (= 1.2.0)
+  delayed_job_active_record (= 4.0.0)
+  enumerize (= 0.7.0)
+  factory_girl (= 4.3.0)
+  git (= 1.2.6)
+  headless (= 1.0.1)
+  mini_magick (= 3.7.0)
+  mysql2 (= 0.3.14)
   padrino (= 0.11.4)
-  pg
-  poltergeist
-  rack-parser
-  rack-test
-  rake
-  redcarpet
-  rspec
-  slim
-  thin
-  typhoeus
-  watir-webdriver
+  pg (= 0.17.1)
+  poltergeist (= 1.5.0)
+  rack-parser (= 0.4.0)
+  rack-test (= 0.6.2)
+  rake (= 10.1.0)
+  redcarpet (= 3.0.0)
+  rspec (= 2.14.1)
+  slim (= 2.0.2)
+  thin (= 1.6.1)
+  typhoeus (= 0.6.7)
+  watir-webdriver (= 0.6.4)


### PR DESCRIPTION
Hoping that we can specify gem versions so that it is easier to insure that production and development environments are the same.

(This pull request includes my previous pull request about the readme consistency. I don't know how to get rid of it.....hope you can cherry-pick just the gem commit.)