### PR TITLE
Define e

### DIFF
--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -224,7 +224,7 @@ class CongressMember < ActiveRecord::Base
                 elem.select_option
               end
             end
-          rescue Capybara::ElementNotFound
+          rescue Capybara::ElementNotFound => e
             raise e, e.message unless a.options == "DEPENDENT"
           end
         when "click_on"


### PR DESCRIPTION
I was getting an `e undefined` when congress-forms couldn't find an element. This makes it so the error is handled as was intended.
