### PR TITLE
Implementing the new Google recaptcha image grid challenges

### DIFF
--- a/app/controllers/main.rb
+++ b/app/controllers/main.rb
@@ -52,7 +52,7 @@ CongressForms::App.controller do
     return {status: "error", message: "The unique id provided was not found."}.to_json unless fh.include? @uid
 
     result = fh[@uid].fill_captcha @answer
-    fh.delete(@uid)
+    fh.delete(@uid) if result[:status] != "captcha_needed"
     result.to_json
   end
 

--- a/app/helpers/form_fill_handler.rb
+++ b/app/helpers/form_fill_handler.rb
@@ -9,7 +9,7 @@ class FillHandler
   def create_thread fields={}, campaign_tag
     @thread = Thread.new do
       begin
-        if DELAY_ALL_NONCAPTCHA_FILLS and not @c.has_captcha? and not @c.has_google_recaptcha? and not @debug
+        if DELAY_ALL_NONCAPTCHA_FILLS and not @c.has_captcha? and not @debug
           @c.delay(queue: "default").fill_out_form fields, campaign_tag
           @result = true
         else

--- a/app/helpers/form_fill_handler.rb
+++ b/app/helpers/form_fill_handler.rb
@@ -9,7 +9,7 @@ class FillHandler
   def create_thread fields={}, campaign_tag
     @thread = Thread.new do
       begin
-        if DELAY_ALL_NONCAPTCHA_FILLS and not @c.has_captcha? and not @debug
+        if DELAY_ALL_NONCAPTCHA_FILLS and not @c.has_captcha? and not @c.has_google_recaptcha? and not @debug
           @c.delay(queue: "default").fill_out_form fields, campaign_tag
           @result = true
         else
@@ -42,10 +42,13 @@ class FillHandler
 
   def fill_captcha answer
     return false unless @thread
-
+    @result = nil
     @answer = answer
     @thread.run
-    @thread.join
+    #@thread.join
+    while @result.nil?
+      Thread.pass
+    end
 
     FillHandler::check_result @result
   end
@@ -61,3 +64,4 @@ class FillHandler
     end
   end
 end
+

--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -214,19 +214,16 @@ class CongressMember < ActiveRecord::Base
                 begin
                   url = self.class::save_google_recaptcha_and_store_poltergeist(session,a.captcha_selector)
                   captcha_value = yield url
-                  frame = session.find(a.captcha_selector)
                   session.within_frame(0) do
-                      for i in captcha_value.split(",")
-                        session.execute_script("document.querySelector('.fbc-imageselect-checkbox-#{i}').checked=true")
-                      end
-                      sleep 0.5
-                      session.find(".fbc-button-verify input").click
-                      @recaptcha_value = session.find("textarea").value
+                    for i in captcha_value.split(",")
+                      session.execute_script("document.querySelector('.fbc-imageselect-checkbox-#{i}').checked=true")
+                    end
+                    sleep 0.5
+                    session.find(".fbc-button-verify input").click
+                    @recaptcha_value = session.find("textarea").value
                   end
                   session.fill_in(a.name,with:@recaptcha_value)
                 rescue Exception => e
-                  url = nil
-                  captcha_value = nil
                   retry
                 end
               else

--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -211,6 +211,7 @@ class CongressMember < ActiveRecord::Base
           if a.value.starts_with?("$")
             if a.value == "$CAPTCHA_SOLUTION"
               if a.options and a.options["google_recaptcha"]
+                self.clear_iframes(session)
                 begin
                   url = self.class::save_google_recaptcha_and_store_poltergeist(session,a.captcha_selector)
                   captcha_value = yield url
@@ -337,6 +338,15 @@ class CongressMember < ActiveRecord::Base
         Process.kill(3, pid)
       end
     end
+  end
+
+  def clear_iframes(session)
+    session.execute_script("
+      var elements = document.querySelectorAll('iframe');
+      Array.prototype.forEach.call(elements, function(el, i){
+        if (!el.parentNode.parentNode.parentNode.parentNode.classList.contains('g-recaptcha')) { el.parentNode.removeChild(el); }
+      });
+    ")
   end
 
   def self.crop_screenshot_from_coords screenshot_location, x, y, width, height

--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -220,7 +220,7 @@ class CongressMember < ActiveRecord::Base
                       session.execute_script("document.querySelector('.fbc-imageselect-checkbox-#{i}').checked=true")
                     end
                     sleep 0.5
-                    session.find(".fbc-button-verify input").click
+                    session.find(".fbc-button-verify input").trigger('click')
                     @recaptcha_value = session.find("textarea").value
                   end
                   session.fill_in(a.name,with:@recaptcha_value)

--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -425,7 +425,7 @@ class CongressMember < ActiveRecord::Base
   end
 
   def has_google_recaptcha?
-    !actions.select{|action|action.options and action.options['google_recaptcha']}.nil?
+    !actions.select{|action|action.options and action.options['google_recaptcha']}.empty?
   end
 
   def check_success body_text

--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -425,7 +425,7 @@ class CongressMember < ActiveRecord::Base
   end
 
   def has_google_recaptcha?
-    !actions.find_by_captcha_selector(".g-recaptcha iframe").nil?
+    !actions.select{|action|action.options and action.options['google_recaptcha']}.nil?
   end
 
   def check_success body_text


### PR DESCRIPTION
This PR implements support for the new google recaptcha image grid and makes some changes to thread behavior on captchas. I explained the captcha behavior on Issue 1434: https://github.com/unitedstates/contact-congress/issues/1434#issuecomment-133526877

Essentially, we're allowing multiple captcha attempts to stay inside the same session. If a page has multiple $CAPTCHA_SOLUTION steps, or requires more than one solution to pass (like recaptcha), we're now keeping the session/thread alive and using it until the fill-out-captcha requests stop returning captcha_needed responses.

As for recaptcha, this is the standard we're using on the yaml files:

```ruby
        - name: "g-recaptcha-response"
          captcha_selector: ".g-recaptcha iframe"
          value: "$CAPTCHA_SOLUTION"
          required: true
          options:
            google_recaptcha: true
```

we check for that google_recaptcha option, set the proper user agent to force the loading of the image grid and save the entire iframe as the captcha image. Here's our implementation on our platform, with some frontend css and js:

<img width="323" alt="skitch" src="https://cloud.githubusercontent.com/assets/43742/9450526/87000842-4a7f-11e5-8b60-bcc35df92afa.png">

The captcha answer is a string of comma separated numbers, corresponding to the image grid position:

```
1 2 3
4 5 6
7 8 9
```
So in the image above it would be "1,5,8,9". Since recaptcha requires multiple correct guesses depending on how suspicious it is of your IP and browser, fill-out-captcha requests will return a new image challenge and the captcha_needed status until it is satisfied.

I guess this is it. I'm having a hard time coming up with a way to test this, given recaptcha's complex workflow. Any help with building tests would be really welcome.