### PR TITLE
bashrc now has cd /vagrant, ruby version bumped, bundler explicitly i…

### DIFF
--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -40,12 +40,14 @@ curl -O https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm
 gpg2 --verify rvm-installer.asc &&
 bash rvm-installer stable
 source /home/vagrant/.rvm/scripts/rvm
-rvm install ruby-2.1.0
+rvm install ruby-2.2.0
 
 cd /vagrant
+gem install bundler
 gem install json -v '1.8.2'
 gem install nokogiri -v '1.6.6.2'
 bundle install
+echo 'cd /vagrant' >> ~/.bashrc
 
 echo "Loading schema..."
 bundle exec rake ar:create ar:schema:load > /dev/null


### PR DESCRIPTION
…nstalled

apparently 'sometimes' ruby doesn't come with bundler, 2.2.0 is one of those versions??

Also thought the cd /vagrant was worth putting in since ~ didn't serve a purpose and one of my first questions when I setup vagrant was "hmm.. I wonder where the important folders are/?" 