### PR TITLE
New recaptcha solving method

### DIFF
--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -90,7 +90,6 @@ class CongressMember < ActiveRecord::Base
     b = Watir::Browser.new :chrome
     begin
       actions.order(:step).each do |a|
-        p "#{a.action} - #{a.value}"
         case a.action
         when "visit"
           b.goto a.value

--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -87,7 +87,7 @@ class CongressMember < ActiveRecord::Base
   # we might want to implement the "wait" option for the "find"
   # directive (see fill_out_form_with_poltergeist)
   def fill_out_form_with_watir f={}
-    b = Watir::Browser.new :chrome
+    b = Watir::Browser.new
     begin
       actions.order(:step).each do |a|
         case a.action

--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -444,7 +444,7 @@ class CongressMember < ActiveRecord::Base
   end
 
   def has_google_recaptcha?
-    !actions.select{|action|action.options and action.options['google_recaptcha']}.empty?
+    !actions.select{|action|action.action and action.action == "recaptcha"}.empty?
   end
 
   def check_success body_text

--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -90,6 +90,7 @@ class CongressMember < ActiveRecord::Base
     b = Watir::Browser.new
     begin
       actions.order(:step).each do |a|
+        p "#{a.action} - #{a.value}"
         case a.action
         when "visit"
           b.goto a.value

--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -87,10 +87,9 @@ class CongressMember < ActiveRecord::Base
   # we might want to implement the "wait" option for the "find"
   # directive (see fill_out_form_with_poltergeist)
   def fill_out_form_with_watir f={}
-    b = Watir::Browser.new
+    b = Watir::Browser.new :chrome
     begin
       actions.order(:step).each do |a|
-        p "#{a.action} - #{a.value}"
         case a.action
         when "visit"
           b.goto a.value
@@ -166,11 +165,7 @@ class CongressMember < ActiveRecord::Base
         when "javascript"
           b.execute_script(a.value)
         when "recaptcha"
-          if ENV["RECAPTCHA_JOBS"]
-            sleep 100
-          else
-            return
-          end
+          sleep 100
         end
       end
 
@@ -325,6 +320,8 @@ class CongressMember < ActiveRecord::Base
           end
         when "javascript"
           session.driver.evaluate_script(a.value)
+        when "recaptcha"
+          raise
         end
       end
 

--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -87,9 +87,10 @@ class CongressMember < ActiveRecord::Base
   # we might want to implement the "wait" option for the "find"
   # directive (see fill_out_form_with_poltergeist)
   def fill_out_form_with_watir f={}
-    b = Watir::Browser.new
+    b = Watir::Browser.new :chrome
     begin
       actions.order(:step).each do |a|
+        p "#{a.action} - #{a.value}"
         case a.action
         when "visit"
           b.goto a.value
@@ -164,6 +165,12 @@ class CongressMember < ActiveRecord::Base
           end
         when "javascript"
           b.execute_script(a.value)
+        when "recaptcha"
+          if ENV["RECAPTCHA_JOBS"]
+            sleep 100
+          else
+            return
+          end
         end
       end
 

--- a/app/models/congress_member_action.rb
+++ b/app/models/congress_member_action.rb
@@ -14,7 +14,7 @@ class CongressMemberAction < ActiveRecord::Base
   serialize :options, LegacySerializer
 
   extend Enumerize
-  enumerize :action, in: %w(visit fill_in select click_on find check uncheck choose wait javascript)
+  enumerize :action, in: %w(visit fill_in select click_on find check uncheck choose wait javascript recaptcha)
 
   def as_required_json o={}
     as_json(REQUIRED_JSON.merge o)

--- a/tasks/phantom-dc.rake
+++ b/tasks/phantom-dc.rake
@@ -45,9 +45,7 @@ namespace :'phantom-dc' do
             cm = CongressMember::retrieve_cached(cm_hash, cm_id)
             puts red("Job #" + job.id.to_s + ", bioguide " + cm.bioguide_id)
             pp cm_args
-            result = cm.fill_out_form_with_watir cm_args[0].merge(overrides)do |img|
-              STDIN.gets.strip
-            end
+            result = cm.fill_out_form_with_watir cm_args[0].merge(overrides)
           rescue
           end
           DelayedJobHelper::destroy_job_and_dependents job
@@ -61,6 +59,7 @@ namespace :'phantom-dc' do
           puts red("Job #" + job.id.to_s + ", bioguide " + cm.bioguide_id)
           pp cm_args
           result = cm.fill_out_form cm_args[0].merge(overrides), cm_args[1] do |img|
+            puts img
             STDIN.gets.strip
           end
         rescue

--- a/tasks/phantom-dc.rake
+++ b/tasks/phantom-dc.rake
@@ -14,6 +14,7 @@ namespace :'phantom-dc' do
 
       jobs = retrieve_jobs args
 
+      recaptcha_jobs = []
       captcha_jobs = []
       noncaptcha_jobs = []
 
@@ -26,7 +27,9 @@ namespace :'phantom-dc' do
           cm = CongressMember::retrieve_cached(cm_hash, cm_id)
 
           if regex.nil? or regex.match(cm.bioguide_id)
-            if retrieve_captchad_cached(captcha_hash, cm.id)
+            if cm.has_google_recaptcha?
+              recaptcha_jobs.push job
+            elsif retrieve_captchad_cached(captcha_hash, cm.id)
               captcha_jobs.push job
             else
               noncaptcha_jobs.push job
@@ -36,7 +39,7 @@ namespace :'phantom-dc' do
       end
 
       if ENV["RECAPTCHA_JOBS"]
-        jobs.each do |job|
+        recaptcha_jobs.each do |job|
           begin
             cm_id, cm_args = DelayedJobHelper::congress_member_id_and_args_from_handler(job.handler)
             cm = CongressMember::retrieve_cached(cm_hash, cm_id)


### PR DESCRIPTION
As discussed earlier, this PR adds a task to solve recaptchas by hand. Let me explain the implementation details below.

First we added a new action type called "recaptcha". This step is used as a way to identify forms who require recaptcha solving and also to perform different actions depending on the execution context. For example, when filling out a form with poltergeist or webkit, the recaptcha action fails the fill instantly so it can go to the failed queue as soon as possible. When filling out a form with watir, the recaptcha step will sleep a few seconds to avoid a watir timeout and further actions while the user solves the recaptcha and submits the form by hand. Having a new action type also ensures that contact-congress implementations other than phantom-dc can safely ignore the step and solve the recaptcha their own way.

Second, the rake task itself. To avoid task duplication, we made minor edits to the main perform_fills task to add the recaptcha fills mode and to make it ignore recaptcha jobs by default to save time. Then we added a new task called perform_recaptcha_fills that "inherits" the perform_fills task and runs it with recaptcha mode activated while accepting the same params.

In recaptcha fills mode only recaptcha jobs will be run, and the fill out method is overridden to use the watir method, regardless of the form settings.

@j-ro  has been solving our own recaptcha forms with it and can describe the resulting workflow better.