### PR TITLE
update_git faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $  docker run -it --rm --name=phantom-dc
       bash -l -c 'rspec spec'
 ```
 
-You may also want to run a cron daemon for your production setup which pulls the latest YAML files from `contact-congress` or your other data sources every so often.  Only run this after giving time (~5min should do it) for the phantom-dc container to initially populate its members of congress upon the first run:
+You may also want to run a cron daemon for your production setup which pulls the latest YAML files from `contact-congress` or your other data sources every so often.  Only run this after giving time for the phantom-dc container to initially populate its members of congress upon the first run:
 
 ```bash
 $  docker run -it --rm --name=phantom-dc-cron \

--- a/tasks/phantom-dc.rake
+++ b/tasks/phantom-dc.rake
@@ -393,7 +393,7 @@ def update_db_member_by_file f, prefix
     begin
       congress_member_details = YAML.load_file(f)
       bioguide = congress_member_details["bioguide"]
-      CongressMember.find_or_create_by(bioguide_id: prefix + bioguide).actions.each { |a| a.destroy }
+      CongressMember.find_or_create_by(bioguide_id: prefix + bioguide).actions.delete_all
       create_congress_member_from_hash congress_member_details, prefix
     rescue Errno::ENOENT
       puts "File " + f + " is missing, skipping..."
@@ -431,7 +431,7 @@ def create_congress_member_from_hash congress_member_details, prefix
           create_action_add_to_member(action, step_increment += 1, c) do |cmf|
             field.each do |attribute|
               if cmf.attributes.keys.include? attribute[0]
-                cmf.update_attribute(attribute[0], attribute[1])
+                cmf.assign_attribute(attribute[0], attribute[1])
               end
             end
           end

--- a/tasks/phantom-dc.rake
+++ b/tasks/phantom-dc.rake
@@ -431,7 +431,7 @@ def create_congress_member_from_hash congress_member_details, prefix
           create_action_add_to_member(action, step_increment += 1, c) do |cmf|
             field.each do |attribute|
               if cmf.attributes.keys.include? attribute[0]
-                cmf.assign_attribute(attribute[0], attribute[1])
+                cmf.assign_attributes(attribute[0] => attribute[1])
               end
             end
           end


### PR DESCRIPTION
These changes cut down the runtime for `bundle exec rake phantom-dc:update_git` on my system from 12m to 20s. `CongressMemberAction` has no destroy callbacks so we can use `delete_all` to clear them. I also use `assign_attribute` rather than `update_attribute`, so there is one UPDATE for the row as a whole when it's saved rather than one per column.
