### PR TITLE
handle CORS requests when browser does preflight checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'watir-webdriver'
 gem 'smarty_streets'
 gem 'groupdate'
 gem 'sentry-raven'
+gem 'rack-cors'
 
 gem 'cwc', path: "./cwc"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: ./cwc
+  remote: cwc
   specs:
     cwc (0.0.1)
       nokogiri
@@ -247,6 +247,7 @@ GEM
       websocket-driver (>= 0.2.0)
     polyglot (0.3.5)
     rack (1.6.4)
+    rack-cors (0.4.1)
     rack-parser (0.6.1)
       rack
     rack-protection (1.5.3)
@@ -344,6 +345,7 @@ DEPENDENCIES
   padrino (>= 0.12.5)
   pg
   poltergeist (= 1.9.0)
+  rack-cors
   rack-parser
   rack-test
   rake
@@ -356,5 +358,8 @@ DEPENDENCIES
   typhoeus
   watir-webdriver
 
+RUBY VERSION
+   ruby 2.2.0p0
+
 BUNDLED WITH
-   1.10.6
+   1.14.3

--- a/app/controllers/debug.rb
+++ b/app/controllers/debug.rb
@@ -6,11 +6,6 @@ CongressForms::App.controller do
   before do
     content_type :json
 
-    if CORS_ALLOWED_DOMAINS.include? request.env['HTTP_ORIGIN'] or CORS_ALLOWED_DOMAINS.include? "*"
-      response.headers['Access-Control-Allow-Origin'] = request.env['HTTP_ORIGIN']
-      response.headers['Access-Control-Allow-Methods'] = "GET, POST, PUT, DELETE"
-      response.headers['Access-Control-Allow-Headers'] = "Content-Type"
-    end
     response.headers['X-Backend-Hostname'] = Socket.gethostname
     halt 401, {status: "error", message: "You must provide a valid debug key to access this endpoint."}.to_json unless params.include? "debug_key" and params["debug_key"] == DEBUG_KEY
   end

--- a/app/controllers/main.rb
+++ b/app/controllers/main.rb
@@ -7,10 +7,6 @@ CongressForms::App.controller do
   end
 
   before do
-    if CORS_ALLOWED_DOMAINS.include? request.env['HTTP_ORIGIN'] or CORS_ALLOWED_DOMAINS.include? "*"
-      response.headers['Access-Control-Allow-Origin'] = request.env['HTTP_ORIGIN']
-      response.headers['Access-Control-Allow-Credentials'] = "true"
-    end
     response.headers['X-Backend-Hostname'] = Socket.gethostname
   end
 

--- a/config/phantom-dc_config.rb.example
+++ b/config/phantom-dc_config.rb.example
@@ -38,4 +38,11 @@ CarrierWave.configure do |config|
   config.fog_directory = ENV_PRIME['FOG_DIRECTORY'] || ''
 end
 
+Padrino.use Rack::Cors do
+  allow do
+    origins CORS_ALLOWED_DOMAINS
+    resource '*', :headers => :any, :methods => [:get, :post, :options]
+  end
+end
+
 TIME_ZONE = ENV_PRIME['TIME_ZONE'] || "America/Los_Angeles"


### PR DESCRIPTION
These changes address #100, where cross origin ajax calls from browsers that do pre-flight checking were failing with a http status code of 405.

Special thanks to @wioux for helpful suggestions.