### PR TITLE
Small fix to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,9 @@ MYSQL_PASSWORD=changeme
 MYSQL_HOST=db
 DEBUG_KEY=changeme
 RACK_ENV=development
-LOAD_CONGRESS=true # or false, depending on whether you want congressional data loaded into your datasource
+
+# or false, depending on whether you want congressional data loaded into your datasource
+LOAD_CONGRESS=true
 
 # CWC integration
 # CWC_API_KEY:


### PR DESCRIPTION
It seems like inline comments (which are totally valid in dotenv) are causing problems when using them directly in the shell, e.g. here in `entrypoint.sh`. 

`if [ "$RACK_ENV" != "test" -a "$(echo "$LOAD_CONGRESS" | tr '[:upper:]' '[:lower:]')" = "true" ]; then`

where the default variable (which includes a comment) does not evaluate to "true" when booting new containers. 

This is almost certainly because the "env_file" directive in docker-compose does not implement the dotenv specification, and just reads the non-comment lines in that file completely.