### PR TITLE
Change cron service setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && \
     libqt5webkit5-dev \
     qt5-default \
     xvfb \
-    lsof && \
+    lsof \
+    cron && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* \
     /tmp/* \

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -29,6 +29,5 @@ services:
   #  env_file: .env
   #  volumes:
   #    - ./docker/cron/update_git:/opt/phantomdc/cron/update_git
-  #    - ./docker/cron/report_queued_jobs:/opt/phantomdc/cron/report_queued_jobs
   #  command: bash -c "env | sed 's@^@export @' >/etc/profile.d/env.sh; cp ./cron/* /etc/cron.d; cron -f"
 

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -22,8 +22,13 @@ services:
   # manually update them via `rake phantom-dc:update_git` within the container.
   #
   #cron:
-  #  image: docker
+  #  build: .
+  #  restart: always
+  #  depends_on:
+  #    - db
+  #  env_file: .env
   #  volumes:
-  #    - /var/run/docker.sock:/var/run/docker.sock
-  #    - ./docker/cron/crontab:/etc/crontabs/root
-  #  command: crond -f
+  #    - ./docker/cron/update_git:/opt/phantomdc/cron/update_git
+  #    - ./docker/cron/report_queued_jobs:/opt/phantomdc/cron/report_queued_jobs
+  #  command: bash -c "env | sed 's@^@export @' >/etc/profile.d/env.sh; cp ./cron/* /etc/cron.d; cron -f"
+

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -1,1 +1,0 @@
-*/15 * * * * docker exec phantomdc_phantomdc_1 bash -l -c 'rake phantom-dc:update_git'

--- a/docker/cron/update_git
+++ b/docker/cron/update_git
@@ -1,0 +1,2 @@
+*/15 * * * * bash -l -c 'cd /opt/phantomdc && bundle exec rake phantom-dc:update_git'
+


### PR DESCRIPTION
Our crontab breaks if you rename the phantomdc service in docker-compose.yml, and you also can't add lines to it without committing them to the public repo. This branch changes the recommended cron setup to improve this.
