### PR TITLE
Message preprocessing

### DIFF
--- a/app/controllers/main.rb
+++ b/app/controllers/main.rb
@@ -128,6 +128,10 @@ CongressForms::App.controller do
 
 
   before :'fill-out-form' do
+    if respond_to?(:preprocess_message) && !preprocess_message(request, params["bio_id"], params["fields"])
+      halt 403, {}, "Access Denied"
+    end
+
     if params["bio_id"] && (cm = CongressMember.bioguide(params["bio_id"]))
       if cwc_office_supported?(cm.cwc_office_code)
         status, headers, body = call env.merge("PATH_INFO" => "/cwc/#{cm.cwc_office_code}/messages")

--- a/app/controllers/main.rb
+++ b/app/controllers/main.rb
@@ -128,7 +128,7 @@ CongressForms::App.controller do
 
 
   before :'fill-out-form' do
-    if respond_to?(:preprocess_message) && !preprocess_message(request, params["bio_id"], params["fields"])
+    if respond_to?(:preprocess_message) && preprocess_message(request, params["bio_id"], params["fields"]) == false
       halt 403, {}, "Access Denied"
     end
 

--- a/app/tasks/perform_fills.rb
+++ b/app/tasks/perform_fills.rb
@@ -39,9 +39,6 @@ class PerformFills
     cm_id, cm_args = DelayedJobHelper::congress_member_id_and_args_from_handler(job.handler)
     cm = CongressMember::retrieve_cached(cm_hash, cm_id)
 
-    puts red("Job #" + job.id.to_s + ", bioguide " + cm.bioguide_id)
-    pp cm_args
-
     fields, campaign_tag = cm_args[0].merge(overrides), cm_args[1]
     fields["$SUBJECT"] ||= fields["$MESSAGE"].truncate_words(13)
 
@@ -50,6 +47,9 @@ class PerformFills
     if respond_to?(:preprocess_job) && preprocess_job(job, cm.bioguide_id, fields) == false
       return true
     end
+
+    puts red("Job #" + job.id.to_s + ", bioguide " + cm.bioguide_id)
+    pp cm_args
 
     if cwc_member?(cm)
       begin

--- a/app/tasks/perform_fills.rb
+++ b/app/tasks/perform_fills.rb
@@ -49,7 +49,7 @@ class PerformFills
     end
 
     puts red("Job #" + job.id.to_s + ", bioguide " + cm.bioguide_id)
-    pp cm_args
+    pp [fields, campaign_tag]
 
     if cwc_member?(cm)
       begin

--- a/app/tasks/perform_fills.rb
+++ b/app/tasks/perform_fills.rb
@@ -47,7 +47,7 @@ class PerformFills
 
     Raven::Context.clear!
 
-    if respond_to?(:preprocess_job) && !preprocess_job(cm.bioguide_id, fields)
+    if respond_to?(:preprocess_job) && preprocess_job(cm.bioguide_id, fields) == false
       return true
     end
 

--- a/app/tasks/perform_fills.rb
+++ b/app/tasks/perform_fills.rb
@@ -82,6 +82,10 @@ class PerformFills
 
       status
     end
+  rescue => e
+    Raven.capture_exception(e, tags: { "rake" => true },
+                            extra: { delayed_job_id: job.id })
+    return false
   end
 
   def cm_hash

--- a/app/tasks/perform_fills.rb
+++ b/app/tasks/perform_fills.rb
@@ -70,9 +70,9 @@ class PerformFills
         false
       end
     elsif recaptcha_member?(cm) && RACK_ENV != "development"
-      cm.fill_out_form_with_watir(cm_args[0].merge(overrides), &block)[:success]
+      cm.fill_out_form_with_watir(fields, &block)[:success]
     elsif RACK_ENV != "development"
-      status = cm.fill_out_form(cm_args[0].merge(overrides), cm_args[1], &block).success?
+      status = cm.fill_out_form(fields, cm_args[1], &block).success?
 
       unless status
         Raven.capture_message("Form error: #{cm.bioguide_id}",

--- a/app/tasks/perform_fills.rb
+++ b/app/tasks/perform_fills.rb
@@ -24,6 +24,8 @@ class PerformFills
     end
 
     queue.each do |job|
+      Raven::Context.clear!
+
       success = run_job(job) do |img|
         puts img
         STDIN.gets.strip
@@ -41,8 +43,6 @@ class PerformFills
 
     fields, campaign_tag = cm_args[0].merge(overrides), cm_args[1]
     fields["$SUBJECT"] ||= fields["$MESSAGE"].truncate_words(13)
-
-    Raven::Context.clear!
 
     if respond_to?(:preprocess_job) && preprocess_job(job, cm.bioguide_id, fields) == false
       return true

--- a/app/tasks/perform_fills.rb
+++ b/app/tasks/perform_fills.rb
@@ -47,7 +47,7 @@ class PerformFills
 
     Raven::Context.clear!
 
-    if respond_to?(:preprocess_job) && preprocess_job(cm.bioguide_id, fields) == false
+    if respond_to?(:preprocess_job) && preprocess_job(job, cm.bioguide_id, fields) == false
       return true
     end
 

--- a/app/tasks/perform_fills.rb
+++ b/app/tasks/perform_fills.rb
@@ -47,6 +47,10 @@ class PerformFills
 
     Raven::Context.clear!
 
+    if respond_to?(:preprocess_job) && !preprocess_job(cm.bioguide_id, fields)
+      return true
+    end
+
     if cwc_member?(cm)
       begin
         fields["$ADDRESS_STATE_POSTAL_ABBREV"] ||= cm.state

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -6,8 +6,11 @@ PADRINO_ROOT = File.expand_path('../..', __FILE__) unless defined?(PADRINO_ROOT)
 require 'rubygems' unless defined?(Gem)
 require 'bundler/setup'
 Bundler.require(:default, RACK_ENV)
+
+require "dotenv/load"
 require "#{Padrino.root}/config/env.rb"
 require "#{Padrino.root}/config/phantom-dc_config.rb"
+
 if File.exists?(file = "#{Padrino.root}/config/constants.rb")
   require file
 end

--- a/spec/controllers/main_controller_spec.rb
+++ b/spec/controllers/main_controller_spec.rb
@@ -201,6 +201,19 @@ describe "Main controller" do
       expect(CampaignTag.last.name).to eq(@campaign_tag)
     end
 
+    it "should 403 Forbidden when #preprocess_message is defined and returns false" do
+      expect_any_instance_of(CongressForms::App).to receive(:preprocess_message){ false }
+
+      c = create :congress_member_with_actions
+      post_json @route, {
+        "bio_id" => c.bioguide_id,
+        "fields" => MOCK_VALUES,
+        "campaign_tag" => @campaign_tag
+      }.to_json
+
+      expect(last_response.status).to eq(403)
+    end
+
     describe "with a captcha" do
       before do
         c = create :congress_member_with_actions_and_captcha

--- a/spec/tasks/perform_fills_spec.rb
+++ b/spec/tasks/perform_fills_spec.rb
@@ -91,6 +91,16 @@ describe PerformFills do
       task.run_job(job)
     end
 
+    it "should call #preprocess_job if defined and not proceed if false" do
+      task = PerformFills.new([job], overrides: overrides)
+
+      expect(task).to receive(:preprocess_job){ false }
+      expect_any_instance_of(CongressMember).not_to receive(:message_via_cwc)
+      expect_any_instance_of(CongressMember).not_to receive(:fill_out_form)
+
+      task.run_job(job)
+    end
+
     context "congress member requires recaptcha" do
       let(:congress_member){ create :congress_member_with_actions_and_recaptcha }
 


### PR DESCRIPTION
This branch allows a deploy-specific hook to reject messages. This basically a stopgap measure for us until we are able to take our public facing instance down.

There is also a hook provided for altering messages as they run through the retry task. I find that many messages need some massaging in order to be resent. For example if a new required field was added to the form we can add that to the message fields if possible.

Files in `app/helpers` are automatically required so it's easy to add the hook there. Contrived example:

```ruby
# app/helpers/message_helper.rb

module MessageHelper
  def preprocess_job(job, bio_id, fields)
    # Senator from California started requiring state abbreviation,
    # but we didn't collect that at the time the message was created
    if bio_id = "A000000" && !fields["$ADDRESS_STATE_POSTAL_ABBREV"].present?
      fields["$ADDRESS_STATE_POSTAL_ABBREV"] = "CA"
    end
  end
end

CongressForms::App.helpers MessageHelper
```
