### PR TITLE
Fix hanging senate forms

### DIFF
--- a/app/models/congress_member.rb
+++ b/app/models/congress_member.rb
@@ -387,6 +387,7 @@ class CongressMember < ActiveRecord::Base
       success_hash
     rescue Exception => e
       form_fill_log(f, "done: unsuccessful fill (#{e.class})")
+      form_fill_log(f, e.message)
       Raven.extra_context(backtrace: e.backtrace)
 
       message = {success: false, message: e.message, exception: e}

--- a/docker/app/entrypoint.sh
+++ b/docker/app/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Kill requests to a senate.gov subdomain that hangs forever
+echo "127.0.0.1 sdc1.senate.gov" >>/etc/hosts
+
 if [ ! -z "$LOAD_SCHEMA_IF_MISSING" -a "$LOAD_SCHEMA_IF_MISSING" == "true" ]; then
    if ! rake ar:version 2>/dev/null; then
        echo "Loading schema..."


### PR DESCRIPTION
Some senate web pages request resources from sdc1.senate.gov, which for a while now has been unable to accept connections. Senator Feinstein for example is unreachable for this reason:

```ruby
[1] pry(main)> Capybara::Session.new(:poltergeist).visit('https://www.feinstein.senate.gov/')
Capybara::Poltergeist::StatusFailError: Request to 'https://www.feinstein.senate.gov/' failed to reach server, check DNS and/or server status - Timed out with the following resources still waiting https://sdc1.senate.gov/NEED_VALUE/wtid.js
```

In this branch I add an /etc/hosts entry mapping sdc1.senate.gov to the loopback IP, so requests there immediately fail and affected pages can continue to load without stalling.