### PR TITLE
Use RACK_ENV instead of PADRINO_ENV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_script:
   - cp config/database.rb.example config/database.rb
   - sed -i "s@^  :username.*@  :username => 'root',@" config/database.rb
   - cp config/phantom-dc_config.rb.example config/phantom-dc_config.rb
-  - "PADRINO_ENV=test bundle exec rake ar:create ar:schema:load"
+  - "RACK_ENV=test bundle exec rake ar:create ar:schema:load"
 script: bundle exec rspec spec

--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ If you haven't set up the test db, create it, using `config/database.rb`
 Then you'll need to create and prepare the test database:
 
 ```bash
-$  PADRINO_ENV=test bundle exec rake ar:create;
-   PADRINO_ENV=test bundle exec rake ar:schema:load
+$  RACK_ENV=test bundle exec rake ar:create;
+   RACK_ENV=test bundle exec rake ar:schema:load
 ```
 
 And run


### PR DESCRIPTION
`Environment variable PADRINO_ENV is deprecated. Please, use RACK_ENV.`